### PR TITLE
fix typos

### DIFF
--- a/app/partials/book.md
+++ b/app/partials/book.md
@@ -449,7 +449,7 @@ PJPEGs can improve compression, consuming [2-10%](http://www.bookofspeed.com/cha
 ### <a id="whos-using-progressive-jpegs-in-production" href="#whos-using-progressive-jpegs-in-production">Who's using Progressive JPEGs in production?</a>
 
 *   [Twitter.com ships Progressive JPEGs](https://www.webpagetest.org/performance_optimization.php?test=170717_NQ_1K9P&run=2#compress_images) with a baseline of quality of 85%. They measured user perceived latency (time to first scan and overall load time) and found overall, PJPEGs were competitive at addressing their requirements for low file-sizes, acceptable transcode and decode times.
-*   [Facebook ships Progressive JPEGs for their iOS app](https://code.facebook.com/posts/857662304298232/faster-photos-in-facebook-for-ios/). They found it reduced data-usage by 15% and enabling them to show a good quality image 15% faster.
+*   [Facebook ships Progressive JPEGs for their iOS app](https://code.facebook.com/posts/857662304298232/faster-photos-in-facebook-for-ios/). They found it reduced data usage by 10% and enabled them to show a good quality image 15% faster.
 *   [Yelp switched to Progressive JPEGs](https://engineeringblog.yelp.com/2017/06/making-photos-smaller.html) and found it was in part responsible for ~4.5% of their image size reduction savings. They also saved an extra 13.8% using MozJPEG.
 
 Many other image-heavy sites, like [Pinterest](https://pinterest.com) also use Progressive JPEGs in production. 


### PR DESCRIPTION
- needless hyphen
- data reduction was 10% not 15 (see [the link](https://code.facebook.com/posts/857662304298232/faster-photos-in-facebook-for-ios/) or a few paragraphs earlier)
- fix tense to match rest of that sentence 