### PR TITLE
fix: Incorrect case in brand name [Flipkart]

### DIFF
--- a/app/partials/book.md
+++ b/app/partials/book.md
@@ -2446,7 +2446,7 @@ Image resources for `<img>`, `<picture>`, `srcset` and SVGs can all take advanta
 
 <aside class="note"><b>Note:</b> `<link rel="preload">` is [supported](http://caniuse.com/#search=preload) in Chrome and Blink-based browsers like Opera, [Safari Tech Preview](https://developer.apple.com/safari/technology-preview/release-notes/) and has been [implemented](https://bugzilla.mozilla.org/show_bug.cgi?id=1222633) in Firefox.</aside>
 
-Sites like [Philips](https://www.usa.philips.com/), [FlipKart](https://www.flipkart.com/) and [Xerox](https://www.xerox.com/) use `<link rel=preload>` to preload their main logo assets (often used early in the document). [Kayak](https://kayak.com/) also uses preload to ensure the hero image for their header is loaded as soon as possible.
+Sites like [Philips](https://www.usa.philips.com/), [Flipkart](https://www.flipkart.com/) and [Xerox](https://www.xerox.com/) use `<link rel=preload>` to preload their main logo assets (often used early in the document). [Kayak](https://kayak.com/) also uses preload to ensure the hero image for their header is loaded as soon as possible.
 
 <figure>
 <picture>


### PR DESCRIPTION
Fixed the case for the brand name Flipkart. Should be in Capitalization case and not the PascalCase.

Reference - https://en.wikipedia.org/wiki/Flipkart