### PR TITLE
Fix ffmpeg GIF conversion command formatting

### DIFF
--- a/app/partials/book.md
+++ b/app/partials/book.md
@@ -1496,7 +1496,7 @@ Why are GIFs many times larger? Animated GIFs store each frame as a lossless GIF
 **If you can switch to videos**
 
 *   Use [ffmpeg](https://www.ffmpeg.org/) to convert your animated GIFs (or sources) to H.264 MP4s. I use this one-liner from[ Rigor](http://rigor.com/blog/2015/12/optimizing-animated-gifs-with-html5-video):
-ffmpeg -i animated.gif -movflags faststart -pix_fmt yuv420p -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" video.mp4
+`ffmpeg -i animated.gif -movflags faststart -pix_fmt yuv420p -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" video.mp4`
 *   ImageOptim API also supports [converting animated gifs to WebM/H.264 video](https://imageoptim.com/api/ungif), [removing dithering from GIFs](https://github.com/kornelski/undither#examples) which can help video codecs compress even more.
 
 **If you must use animated GIFs**


### PR DESCRIPTION
The ffmpeg command to convert GIFs to MP4s was not in back-ticks so it was being rendered as markdown. This caused the command to render incorrectly since the command contains asterisks which are significant markdown syntax. This incorrect rendering means that you can no longer copy & paste the example.

Before:
![image](https://user-images.githubusercontent.com/8633/49755033-c887e800-fc85-11e8-973e-3ede96cb6a30.png)

After:
![image](https://user-images.githubusercontent.com/8633/49755064-da698b00-fc85-11e8-9670-edf9677ed915.png)


Thank you for this wonderful guide.